### PR TITLE
fix: add undeclared dependency `lodash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "version": "1.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "invariant": "2.2.4"
+        "invariant": "2.2.4",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "babel-cli": "^6.26.0",
@@ -3519,8 +3520,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "3.0.0",
@@ -9631,8 +9631,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "invariant": "2.2.4"
+    "invariant": "2.2.4",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`query-ast` depends on `lodash` but doesn't declare it as a dependency

**How did you fix it?**

Added `lodash` as a dependency